### PR TITLE
Correct key type in verification method

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,5 +7,6 @@ export const VERIFIABLE_PRESENTATION = "VerifiablePresentation";
 export const ECDSA_SECP_256_K1_SIGNATURE_2019 = "EcdsaSecp256k1Signature2019";
 export const ECDSA_SECP_256_K1_VERIFICATION_KEY_2019 =
   "EcdsaSecp256k1VerificationKey2019";
+export const JSON_WEB_Key_2020 = "JsonWebKey2020";
 export const ES256K = "ES256K";
 export const ASSERTION_METHOD = "assertionMethod";

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,7 +7,7 @@ import {
   OIDC_ISSUE,
   VERIFIABLE_PRESENTATION,
   ECDSA_SECP_256_K1_SIGNATURE_2019,
-  ECDSA_SECP_256_K1_VERIFICATION_KEY_2019,
+  JSON_WEB_Key_2020,
   ES256K,
   ASSERTION_METHOD,
 } from "./constants";
@@ -158,7 +158,6 @@ export const sendApiTransaction = async (
   callback: any
 ) => {
   const url = `https://api.preprod.ebsi.eu/did-registry/v2/jsonrpc`;
-  callback();
   const response = await jsonrpcSendTransaction(client, token, url, method, param);
 
   if (response.status < 400 && (await waitToBeMined(response.data.result))) {
@@ -208,9 +207,7 @@ export const prepareUpdateDidDocument = async (
 
   didDocument =
     didDoc == null || Object.keys(didDoc).length < 3 ? await resolveDid(didUser) : didDoc;
-  console.log("resolved Did Doc");
   console.log(didDocument);
-  console.log(didDoc);
   //let publicKeyObjects: Array<object> = didDocument.get("verificationMethod"); 
   //const controller = new ethers.Wallet(privateKeyController);
   // let publicKey = {
@@ -233,7 +230,7 @@ function fromHexString(hexString) {
 const verificationMethod = (didUser: string, publicKey: object) => {
   return {
     id: `${didUser}#keys-1`,
-    type: ECDSA_SECP_256_K1_VERIFICATION_KEY_2019,
+    type: JSON_WEB_Key_2020,
     controller: didUser,
     ...publicKey,
   };


### PR DESCRIPTION
Verification key type updated to "JsonWebKey2020" from "EcdsaSecp256k1VerificationKey2019"  because the registrar driver by default support keys in JWK format.